### PR TITLE
read <url> element if present

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -25,6 +25,7 @@ module.exports = function parse(xml) {
 					license: t('recording license'),
 					optout: t('recording optout') !== 'false', // Treat anything as true that's not explicitly false
 				},
+				url: $event.find("url").text(),
 				persons: $event.find('persons person').map((i, person) => ({
 					id: $(person).attr('id'),
 					name: $(person).text(),

--- a/lib/template.js
+++ b/lib/template.js
@@ -42,6 +42,7 @@ module.exports = function Template(options) {
 		const { title, room, start, duration, id, language, sequentialNumber, guid } = event;
 		const speakers = event.persons.map(p => p.name).join(', ');
 		const type = o.ignoreEventTypes.includes(event.type) ? '' : ` (${_.upperFirst(event.type)})`;
+		const url = event.url || `${options.baseUrl}events/${id}.html`;
 
 		const targetLanguages = ({
 			en: '→ de: ',
@@ -55,7 +56,7 @@ module.exports = function Template(options) {
 			[${language}] <strong>${start}</strong> +${duration}, ${room}<br>
 			<strong>${title}</strong>${type}<br>
 			${speakers}<br>
-			Fahrplan: ${options.baseUrl}events/${id}.html<br>
+			Fahrplan: ${url}<br>
 			Slides (if available): https://speakers.c3lingo.org/talks/${guid}/<br>
 			${targetLanguages}<br>
 			<br>


### PR DESCRIPTION
These days events have their URLs supplied in the data, no need to derive the URL from base URL and event ID. The old logic has been retained as a fallback though.