### PR TITLE
add room-filtering capability

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,7 +2,7 @@
 
 const cheerio = require('cheerio');
 
-module.exports = function parse(xml) {
+module.exports = function parse(xml, rooms) {
 	const $ = cheerio.load(xml);
 
 	const version = $('schedule version').text();
@@ -10,9 +10,17 @@ module.exports = function parse(xml) {
 	const acronym = $('conference acronym').text();
 	const baseUrl = $('conference base_url').text();
 
+	const filterRooms = rooms && rooms.length;
+	const roomFilter = {};
+	for (let roomName of rooms || []) {
+		roomFilter[roomName] = true;
+	}
+
 	const days = $('day').map((i, day) => {
 		const $day = $(day);
-		const events = $day.find('event').map((i, event) => {
+		const events = $day.find('room').filter((i, room) => {
+			return filterRooms ? $(room).attr('name') in roomFilter : true;
+		}).find('event').map((i, event) => {
 			const $event = $(event);
 			const t = (selector) => $event.find(selector).text() || null;
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -11,15 +11,11 @@ module.exports = function parse(xml, rooms) {
 	const baseUrl = $('conference base_url').text();
 
 	const filterRooms = rooms && rooms.length;
-	const roomFilter = {};
-	for (let roomName of rooms || []) {
-		roomFilter[roomName] = true;
-	}
 
 	const days = $('day').map((i, day) => {
 		const $day = $(day);
 		const events = $day.find('room').filter((i, room) => {
-			return filterRooms ? $(room).attr('name') in roomFilter : true;
+			return filterRooms ? rooms.indexOf($(room).attr('name')) !== -1 : true;
 		}).find('event').map((i, event) => {
 			const $event = $(event);
 			const t = (selector) => $event.find(selector).text() || null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c3t-pad",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Convert Chaos Communication Congress schedule into pads for the translation team",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The schedule data might contain more rooms than we want to serve. This adds two command line options which both restrict the rooms for which the HTML is produced. One takes the room list from the command line, the other from a file.